### PR TITLE
Fix Package.json and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Merge-CIDRs
-Given a pair of CIDRs (in either string format `"127.0.0.1/32"` or as `ip.cidrSubnet` objects), return an `ip.cidrSubnet` structure representing the smallest CIDR which encompasses both of the original CIDR blocks.
+Given a pair of CIDR blocks, return the smallest CIDR which encompasses both of the original CIDR blocks.
 
 Install with:
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "merge-cidrs",
   "private": false,
   "version": "1.0.0",
-  "license": "",
+  "license": "MIT",
+  "main": "./lib/index",
   "repository" : {
       "type" : "git",
       "url" : "https://github.com/Furchin/merge-cidrs"


### PR DESCRIPTION
1. Remove markdown from readme summary as it seems to display poorly on npmjs.
2. Add `main` to package.json
3. Add license to package.json
